### PR TITLE
SSL Missing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ IMAGE_NAME =            cowsay
 ## Image tools  (https://github.com/scaleway/image-tools)
 all:	docker-rules.mk
 docker-rules.mk:
-	wget -qO - http://j.mp/scw-builder | bash
+	wget -qO - https://j.mp/scw-builder | bash
 -include docker-rules.mk
 ```
 


### PR DESCRIPTION
As i have pointed out on twitter. This STILL IS a horrible thing to do.
You have NO control on the external domain and there is a possibility that someone could hijack this bit.ly link.

ATLEAST create an internal scaleway domain for this, so you have a little more control.