### PR TITLE
Upgrade scw to 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get -qq update     \
  && apt-get clean
 
 # Download scw
-ENV SCW_VERSION 1.10.1
+ENV SCW_VERSION 1.14
 
 RUN case "${ARCH}" in                                                                                                               \
 	armv7l|armhf|arm)                                                                                                               \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME =			image-builder
 VERSION =		latest
-VERSION_ALIASES = 	1.4.3 1.4 1
+VERSION_ALIASES = 	1.4.4 1.4 1
 TITLE =			image-builder
 DESCRIPTION =		An image to build other images
 SOURCE_URL =		https://github.com/scaleway/image-builder
@@ -8,7 +8,7 @@ SOURCE_URL =		https://github.com/scaleway/image-builder
 
 IMAGE_VOLUME_SIZE =	50G
 IMAGE_BOOTSCRIPT =	docker
-IMAGE_NAME =		Image Builder 1.4.3
+IMAGE_NAME =		Image Builder 1.4.4
 
 DEFAULT_IMAGE_ARCH = x86_64
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ You can contact the admins of #scaleway on `irc.online.net`.
 
 ## Changelog
 
+### 1.4.4 (unreleased)
+
+* Bump scw @1.14
+
 ### 1.4.3 (2016-10-24)
 
 * Bump scw @1.10.1


### PR DESCRIPTION
Beside upgrading the scw utility I have also directly raised the
image-builder version to 1.4.4.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>